### PR TITLE
feat: Add NDJSON streaming and media generation endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
-[![Interface](https://img.shields.io/badge/Interface-REST_+_SSE-purple?style=for-the-badge&logo=fastapi&logoColor=white)](#-api-overview)
+[![Interface](https://img.shields.io/badge/Interface-REST_+_Streaming_(NDJSON)-purple?style=for-the-badge&logo=fastapi&logoColor=white)](#-api-overview)
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-Available-85ea2d?style=for-the-badge&logo=openapi-initiative&logoColor=white)](/docs)
 
 [![Try API](https://img.shields.io/badge/🚀_Try_API-OpenAPI_UI-0ea5e9?style=for-the-badge)](/docs)
@@ -22,7 +22,7 @@
     <tr>
       <td align="center">🔌<br><b>Unified Gateway</b><br>Single HTTP surface for all providers</td>
       <td align="center">🔐<br><b>Secure Keys</b><br>Secrets remain server‑side</td>
-      <td align="center">🌊<br><b>Streaming</b><br>SSE token-by-token responses</td>
+      <td align="center">🌊<br><b>Streaming</b><br>NDJSON token-by-token responses</td>
       <td align="center">📦<br><b>Uploads</b><br>Images, Audio, PDFs via multipart</td>
     </tr>
   </table>
@@ -106,7 +106,7 @@ cp .env.example .env
   - `GET /v1/models?capability=&provider=` — capability/provider‑filtered models (from registry)
 - Text
   - `POST /v1/text/generate` — JSON body, returns `AIResponse`
-  - `GET /v1/text/stream` — SSE stream of tokens
+  - `POST /v1/text/stream` — NDJSON stream of tokens
 - Images
   - `POST /v1/images/generate` — JSON body
   - `POST /v1/images/edit` — multipart (image + prompt)
@@ -117,19 +117,15 @@ cp .env.example .env
 - Embeddings
   - `POST /v1/embeddings/generate` — JSON (single or batch)
 
-## 🌊 Streaming (SSE)
+## 🌊 Streaming (NDJSON)
 
-- Event types: `delta`, `final`, `error` (usage events temporarily removed)
-- Message shape (example):
+- Content type: `application/x-ndjson`
+- Each line is a JSON object; when the stream ends, the connection closes
+- Chunk shape (example):
 
-```text
-event: delta
-data: {"content":"Hello"}
-
-# usage event removed for now
-
-event: final
-data: {"content":"Hello world","is_final":true}
+```json
+{"content":"Hello","provider":"openai","model":"gpt-4o-mini","metadata":{"is_stream_chunk":true}}
+{"content":" world","provider":"openai","model":"gpt-4o-mini","metadata":{"is_stream_chunk":true}}
 ```
 
 ## 💻 Usage Examples
@@ -146,15 +142,19 @@ curl -X POST http://localhost:8000/v1/text/generate \
   -d '{"provider":"openai","model":"gpt-4o-mini","prompt":"Write a haiku about the ocean"}'
 ```
 
-### Streaming (SSE)
+### Streaming (NDJSON)
 ```bash
-curl -N "http://localhost:8000/v1/text/stream?provider=openai&model=gpt-4o-mini&prompt=Hello"
+curl -N \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/x-ndjson' \
+  -d '{"provider":"openai","model":"gpt-4o-mini","prompt":"Hello"}' \
+  http://localhost:8000/v1/text/stream
 ```
 
 ## 🗺️ Roadmap
 
 - [ ] Implement v1 endpoints for all capabilities
-- [ ] SSE streaming for text/audio/doc
+- [ ] Streaming (NDJSON) for text/audio/doc
 - [ ] Unified error envelope and usage reporting
 - [ ] OpenAPI client generation for `celeste-ui`
 - [ ] Auth (optional) and rate limiting

--- a/src/celeste_api/main.py
+++ b/src/celeste_api/main.py
@@ -1,23 +1,15 @@
 from __future__ import annotations
 
 import os
-from importlib.metadata import PackageNotFoundError, version
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from celeste_api.routes import discovery
-from celeste_api.routes import text
+from celeste_api.routes import discovery, text, images, videos
+from celeste_api import __version__
 
 
-def _get_version() -> str:
-    try:
-        return version("celeste-api")
-    except PackageNotFoundError:
-        return "0.1.0"
-
-
-app = FastAPI(title="Celeste API", version=_get_version())
+app = FastAPI(title="Celeste API", version=__version__)
 
 
 origins_raw = os.getenv("CORS_ALLOW_ORIGINS", "*")
@@ -34,7 +26,7 @@ app.add_middleware(
 
 @app.get("/v1/health")
 async def health() -> dict[str, str]:
-    return {"status": "ok", "version": _get_version()}
+    return {"status": "ok", "version": __version__}
 
 
 @app.get("/")
@@ -45,3 +37,5 @@ async def root() -> dict[str, str]:
 # Routers
 app.include_router(discovery.router)
 app.include_router(text.router)
+app.include_router(images.router)
+app.include_router(videos.router)

--- a/src/celeste_api/routes/images.py
+++ b/src/celeste_api/routes/images.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from celeste_core.types.image import ImageArtifact
-from celeste_image_generation.providers.google import GoogleImageGenerator
-from celeste_image_generation.providers.openai import OpenAIImageGenerator
+from celeste_image_generation import create_image_generator
 
 
 router = APIRouter(prefix="/v1", tags=["images"])
@@ -17,10 +16,7 @@ async def generate_images(payload: dict):
     prompt = payload["prompt"]
     options = payload.get("options", {})
 
-    if provider == "google":
-        client = GoogleImageGenerator(model=model or "imagen-3.0-generate-002")
-    else:
-        client = OpenAIImageGenerator(model=model or "dall-e-3")
+    client = create_image_generator(provider, model=model)
 
     images: list[ImageArtifact] = await client.generate_image(prompt, **options)
     return {

--- a/src/celeste_api/routes/text.py
+++ b/src/celeste_api/routes/text.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from celeste_client import create_client
 from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+import json
 
 from celeste_core import Capability
-from celeste_client import create_client
-
 
 router = APIRouter(prefix="/v1", tags=["text"])
 
@@ -23,3 +24,27 @@ async def generate_text(payload: dict):
         "model": model,
         "metadata": response.metadata,
     }
+
+
+@router.post("/text/stream")
+async def stream_text(payload: dict):
+    provider = payload["provider"]
+    model = payload["model"]
+    prompt = payload["prompt"]
+
+    client = create_client(provider, model=model, capability=Capability.TEXT_GENERATION)
+
+    async def ndjson_generator():
+        async for chunk in client.stream_generate_content(prompt):
+            metadata = chunk.metadata or {}
+            if not metadata.get("is_stream_chunk"):
+                metadata = {**metadata, "is_stream_chunk": True}
+            line = {
+                "content": chunk.content,
+                "provider": provider,
+                "model": model,
+                "metadata": metadata,
+            }
+            yield json.dumps(line, ensure_ascii=False) + "\n"
+
+    return StreamingResponse(ndjson_generator(), media_type="application/x-ndjson")

--- a/src/celeste_api/routes/videos.py
+++ b/src/celeste_api/routes/videos.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from celeste_core.types.video import VideoArtifact
+from celeste_video_generation import create_video_client
+
+
+router = APIRouter(prefix="/v1", tags=["videos"])
+
+
+@router.post("/video/generate")
+async def generate_video(payload: dict):
+    provider = payload["provider"]
+    model = payload.get("model")
+    prompt = payload["prompt"]
+    options = payload.get("options", {})
+
+    client = create_video_client(provider, model=model)
+    response = await client.generate_content(prompt, **options)
+    videos: list[VideoArtifact] = response.content
+    return {
+        "videos": [
+            {
+                "url": v.url,
+                "path": v.path,
+                "metadata": response.metadata,
+            }
+            for v in videos
+        ]
+    }


### PR DESCRIPTION
## Summary
- Replace SSE streaming with NDJSON format for improved compatibility and simpler client implementation
- Add image and video generation endpoints to support media creation capabilities
- Modernize streaming endpoint from GET to POST with consistent request/response patterns

## Changes
- **Streaming Format**: Migrated from Server-Sent Events (SSE) to NDJSON streaming
  - Changed `/v1/text/stream` from GET to POST endpoint
  - Each line is now a complete JSON object with content, provider, model, and metadata
  - Simpler client implementation without SSE event parsing

- **New Endpoints**: 
  - `POST /v1/images/generate` - Generate images using various providers
  - `POST /v1/video/generate` - Generate videos with provider support
  
- **Code Improvements**:
  - Simplified version handling in main.py
  - Added proper router imports for new endpoints
  - Consistent response structure across all media endpoints

## Test Plan
- [ ] Test NDJSON streaming with curl and verify line-delimited JSON output
- [ ] Test image generation endpoint with different providers
- [ ] Test video generation endpoint functionality
- [ ] Verify backward compatibility is maintained for other endpoints
- [ ] Confirm OpenAPI documentation reflects new endpoints correctly