### PR TITLE
feat: Add image editing endpoint

### DIFF
--- a/src/celeste_api/routes/images.py
+++ b/src/celeste_api/routes/images.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
 from fastapi import APIRouter
 
 from celeste_core.types.image import ImageArtifact
 from celeste_image_generation import create_image_generator
+from celeste_image_edit import create_image_editor
 
 
 router = APIRouter(prefix="/v1", tags=["images"])
@@ -32,4 +34,33 @@ async def generate_images(payload: dict):
             }
             for img in images
         ]
+    }
+
+
+@router.post("/images/edit")
+async def edit_image(payload: dict):
+    # Parse request data - NO validation, let it fail
+    provider = payload["provider"]
+    model = payload.get("model")
+    prompt = payload["prompt"]
+    image_data = payload["image"]  # Base64 string
+    options = payload.get("options", {})
+
+    # Decode base64 to bytes - NO error handling
+    image_bytes = base64.b64decode(image_data)
+
+    # Create image artifact
+    input_image = ImageArtifact(data=image_bytes)
+
+    # Create editor and perform edit
+    editor = create_image_editor(provider, model=model)
+    result = await editor.edit_image(prompt=prompt, image=input_image, **options)
+
+    # Return edited image as base64
+    return {
+        "image": {
+            "data": base64.b64encode(result.data).decode("utf-8") if result.data else None,
+            "path": result.path,
+            "metadata": result.metadata,
+        }
     }


### PR DESCRIPTION
## Summary
- Added new `/v1/images/edit` POST endpoint for image editing capabilities
- Supports base64-encoded image input and output
- Integrates with multiple image editing providers through `celeste_image_edit`

## Changes
- New endpoint accepts provider, model, prompt, and base64 image data
- Decodes input image, processes it through the editor, and returns edited result
- Maintains consistency with existing image generation endpoint patterns

## Test Plan
- [ ] Test endpoint with valid base64 image data
- [ ] Verify different provider configurations work correctly
- [ ] Confirm error handling for invalid input
- [ ] Check response format matches expected structure