### PR TITLE
Update celeste-core to use Git source instead of workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "python-multipart>=0.0.9",
   "sse-starlette>=1.6.1",
   "celeste-client>=0.1.0",
+  "httpx>=0.27.0",
 ]
 
 [tool.ruff]
@@ -29,4 +30,4 @@ where = ["src"]
 
 [tool.uv.sources]
 celeste-client = { workspace = true }
-celeste-core = { workspace = true }
+celeste-core = { git = "https://github.com/celeste-kai/celeste-core.git" }


### PR DESCRIPTION
## Summary
- Updated celeste-core dependency to use Git source instead of workspace reference
- This fixes UV workspace configuration issues while maintaining external installability

## Test plan
- [x] UV sync runs successfully
- [x] Package builds correctly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)