### PR TITLE
fix: Use proper base64 encoding for image data and add cloud build config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,44 @@
+steps:
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/celeste/celeste-api:$_IMAGE_TAG', '.']
+
+  # Push the container image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/celeste/celeste-api:$_IMAGE_TAG']
+
+  # Deploy container image to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'celeste-api'
+      - '--image'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/celeste/celeste-api:$_IMAGE_TAG'
+      - '--region'
+      - 'us-central1'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--port'
+      - '8080'
+      - '--memory'
+      - '1Gi'
+      - '--cpu'
+      - '1'
+      - '--min-instances'
+      - '0'
+      - '--max-instances'
+      - '10'
+      - '--set-env-vars'
+      - 'PORT=8080,CORS_ALLOW_ORIGINS=https://celeste-ai.co'
+
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/celeste/celeste-api:$_IMAGE_TAG'
+
+substitutions:
+  _IMAGE_TAG: $COMMIT_SHA
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/src/celeste_api/routes/images.py
+++ b/src/celeste_api/routes/images.py
@@ -24,7 +24,7 @@ async def generate_images(payload: dict):
         "images": [
             {
                 "data": (
-                    img.data.decode("latin1")
+                    base64.b64encode(img.data).decode("utf-8")
                     if isinstance(img.data, (bytes, bytearray))
                     else img.data
                 ),


### PR DESCRIPTION
## Summary
• Fixed image data encoding from `latin1` to proper `base64` encoding in `src/celeste_api/routes/images.py:27`
• Added `cloudbuild.yaml` configuration for GCP deployment

## Test plan
- [ ] Verify image generation API returns properly encoded base64 data
- [ ] Test cloud build deployment configuration
- [ ] Ensure all existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)