### PR TITLE
feat: Add audio/TTS generation endpoint

### DIFF
--- a/src/celeste_api/main.py
+++ b/src/celeste_api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from celeste_api import __version__
-from celeste_api.routes import discovery, images, rerank, text, videos
+from celeste_api.routes import audio, discovery, images, rerank, text, videos
 
 app = FastAPI(title="Celeste API", version=__version__)
 
@@ -38,4 +38,5 @@ app.include_router(discovery.router)
 app.include_router(text.router)
 app.include_router(images.router)
 app.include_router(videos.router)
+app.include_router(audio.router)
 app.include_router(rerank.router)

--- a/src/celeste_api/routes/audio.py
+++ b/src/celeste_api/routes/audio.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import base64
+
+from celeste_core.types.audio import AudioArtifact
+from celeste_text_to_speech import GoogleTTSClient
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/v1", tags=["audio"])
+
+
+@router.post("/audio/generate")
+async def generate_audio(payload: dict) -> dict:
+    """Generate audio/speech from text using TTS."""
+    provider = payload["provider"]
+    model = payload.get("model", "gemini-2.5-flash-preview-tts")
+    text = payload["text"]
+    options = payload.get("options", {})
+
+    # Extract voice_name from options, default to a common voice
+    voice_name = options.pop("voice", "Zephyr")
+
+    # For now, we only support Google TTS
+    if provider.lower() != "google":
+        raise ValueError(f"Provider {provider} not yet supported for TTS")
+
+    client = GoogleTTSClient(model=model)
+    audio_artifact: AudioArtifact = await client.generate_speech(text=text, voice_name=voice_name, **options)
+
+    # Convert audio bytes to base64
+    audio_base64 = base64.b64encode(audio_artifact.data).decode("utf-8") if audio_artifact.data else None
+
+    return {
+        "audio": {
+            "data": audio_base64,
+            "format": audio_artifact.format or "wav",
+            "sample_rate": audio_artifact.sample_rate,
+            "metadata": {
+                "model": model,
+                "voice": voice_name,
+            },
+        }
+    }

--- a/src/celeste_api/routes/text.py
+++ b/src/celeste_api/routes/text.py
@@ -35,7 +35,7 @@ async def stream_text(payload: dict) -> StreamingResponse:
 
     client = create_client(provider, model=model, capability=Capability.TEXT_GENERATION)
 
-    async def ndjson_generator() -> AsyncGenerator[str, None]:
+    async def ndjson_generator() -> AsyncGenerator[str]:
         async for chunk in client.stream_generate_content(prompt):
             metadata = chunk.metadata or {}
             if not metadata.get("is_stream_chunk"):


### PR DESCRIPTION
## Summary
- Added new `/v1/audio/generate` endpoint for text-to-speech generation
- Integrated Google TTS client with configurable voices and models
- Fixed async generator type hints for better type checking

## Changes
- Created new `audio.py` route module with TTS endpoint
- Added audio router to main FastAPI application
- Fixed type hints in text and video routes (removed `None` from AsyncGenerator)
- Properly handle base64 encoding for audio data response

## Test Plan
- [ ] Test `/v1/audio/generate` endpoint with Google provider
- [ ] Verify different voice options work correctly
- [ ] Confirm base64 audio data is properly formatted
- [ ] Check error handling for unsupported providers

🤖 Generated with [Claude Code](https://claude.ai/code)